### PR TITLE
Add Vercel function entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ Open your browser and navigate to:
 - **Backend API**: http://localhost:8000
 - **API Documentation**: http://localhost:8000/docs
 
+### 4. Deploying with Vercel
+
+The repository includes a `vercel.json` file that exposes the FastAPI app as a
+serverless function. Use the Vercel CLI to run locally or deploy:
+
+```bash
+# Install the Vercel CLI if needed
+npm install -g vercel
+
+# Start a local Vercel environment
+vercel dev
+
+# Deploy to your Vercel account
+vercel --prod
+```
+
 ---
 
 ## 📊 Features & Usage

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,1 @@
+from backend.main import app

--- a/vercel.json
+++ b/vercel.json
@@ -1,22 +1,16 @@
 {
   "version": 2,
   "builds": [
-    {
-      "src": "backend/main.py",
-      "use": "@vercel/python"
-    }
+    { "src": "api/index.py", "use": "@vercel/python" }
   ],
-"functions": {
-  "backend/main.py": {
-    "maxDuration": 60,
-    "memory": 1024,
-    "excludeFiles": "{node_modules/**,tests/**,__pycache__/**}"
-  }
-},
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "backend/main.py"
+  "functions": {
+    "api/index.py": {
+      "maxDuration": 60,
+      "memory": 1024,
+      "excludeFiles": "{node_modules/**,tests/**,__pycache__/**}"
     }
+  },
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.py" }
   ]
 }


### PR DESCRIPTION
## Summary
- configure Vercel build to use `api/index.py`
- expose FastAPI app from new `api` folder
- document Vercel build process in the README

## Testing
- `yarn test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_b_68527fbe1714832088eb1c9f68cbc684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new section to the Quick Start guide with instructions for deploying the app using Vercel.

- **Chores**
  - Updated deployment configuration to reference a new serverless function entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->